### PR TITLE
Create P0 Stubs

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -4,6 +4,8 @@ android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
 
+    dataBinding.enabled = true
+
     defaultConfig {
         applicationId "com.cnj.naslink"
         minSdkVersion 24
@@ -26,9 +28,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 }

--- a/src/app/src/androidTest/java/com/cnj/naslink/connect/ConnectActivityTest.java
+++ b/src/app/src/androidTest/java/com/cnj/naslink/connect/ConnectActivityTest.java
@@ -1,0 +1,7 @@
+package com.cnj.naslink.connect;
+
+/**
+ * Contains the instrumentation test for the {@link ConnectActivity} class.
+ */
+public class ConnectActivityTest {
+}

--- a/src/app/src/androidTest/java/com/cnj/naslink/filebrowse/FileBrowseActivityTest.java
+++ b/src/app/src/androidTest/java/com/cnj/naslink/filebrowse/FileBrowseActivityTest.java
@@ -1,0 +1,7 @@
+package com.cnj.naslink.filebrowse;
+
+/**
+ * Contains the instrumentation tests for the {@link FileBrowseActivity} class.
+ */
+public class FileBrowseActivityTest {
+}

--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <activity android:name=".filebrowse.FileBrowseActivity"></activity>
+        <activity android:name=".connect.ConnectActivity" />
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/src/app/src/main/java/com/cnj/naslink/connect/ConnectActivity.java
+++ b/src/app/src/main/java/com/cnj/naslink/connect/ConnectActivity.java
@@ -1,0 +1,28 @@
+package com.cnj.naslink.connect;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.databinding.DataBindingUtil;
+import androidx.lifecycle.ViewModelProviders;
+
+import android.os.Bundle;
+
+import com.cnj.naslink.R;
+import com.cnj.naslink.databinding.ActivityConnectBinding;
+
+/**
+ * The activity that allows a user to connect to a freeNAS server.
+ */
+public class ConnectActivity extends AppCompatActivity {
+    private ConnectViewModel mConnectViewModel;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // creates the view model and attaches it to the activity to allow for binding
+        ActivityConnectBinding dataBinding = DataBindingUtil.setContentView(this,
+                R.layout.activity_connect);
+        mConnectViewModel = ViewModelProviders.of(this).get(ConnectViewModel.class);
+        dataBinding.setViewModel(mConnectViewModel);
+    }
+}

--- a/src/app/src/main/java/com/cnj/naslink/connect/ConnectViewModel.java
+++ b/src/app/src/main/java/com/cnj/naslink/connect/ConnectViewModel.java
@@ -1,0 +1,9 @@
+package com.cnj.naslink.connect;
+
+import androidx.lifecycle.ViewModel;
+
+/**
+ * The View model for the connect activity.
+ */
+public class ConnectViewModel extends ViewModel {
+}

--- a/src/app/src/main/java/com/cnj/naslink/connect/ConnectionInfo.java
+++ b/src/app/src/main/java/com/cnj/naslink/connect/ConnectionInfo.java
@@ -1,0 +1,7 @@
+package com.cnj.naslink.connect;
+
+/**
+ * The model class for connecting to a freeNAS server.
+ */
+public class ConnectionInfo {
+}

--- a/src/app/src/main/java/com/cnj/naslink/filebrowse/File.java
+++ b/src/app/src/main/java/com/cnj/naslink/filebrowse/File.java
@@ -1,0 +1,7 @@
+package com.cnj.naslink.filebrowse;
+
+/**
+ * The model class that represents a single file on a freeNAS server.
+ */
+public class File {
+}

--- a/src/app/src/main/java/com/cnj/naslink/filebrowse/FileBrowseActivity.java
+++ b/src/app/src/main/java/com/cnj/naslink/filebrowse/FileBrowseActivity.java
@@ -1,0 +1,28 @@
+package com.cnj.naslink.filebrowse;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.databinding.DataBindingUtil;
+import androidx.lifecycle.ViewModelProviders;
+
+import android.os.Bundle;
+
+import com.cnj.naslink.R;
+import com.cnj.naslink.databinding.ActivityFileBrowseBinding;
+
+/**
+ * The activity that allows users to browser files on a freeNAS server.
+ */
+public class FileBrowseActivity extends AppCompatActivity {
+    private FileBrowseViewModel mFileBrowseViewModel;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // creates the view model and attaches it to the activity to allow for binding
+        ActivityFileBrowseBinding dataBinding = DataBindingUtil.setContentView(this,
+                R.layout.activity_file_browse);
+        mFileBrowseViewModel = ViewModelProviders.of(this).get(FileBrowseViewModel.class);
+        dataBinding.setViewmodel(mFileBrowseViewModel);
+    }
+}

--- a/src/app/src/main/java/com/cnj/naslink/filebrowse/FileBrowseViewModel.java
+++ b/src/app/src/main/java/com/cnj/naslink/filebrowse/FileBrowseViewModel.java
@@ -1,0 +1,9 @@
+package com.cnj.naslink.filebrowse;
+
+import androidx.lifecycle.ViewModel;
+
+/**
+ * The view model class for the file browser activity.
+ */
+public class FileBrowseViewModel extends ViewModel {
+}

--- a/src/app/src/main/java/com/cnj/naslink/server/NASServer.java
+++ b/src/app/src/main/java/com/cnj/naslink/server/NASServer.java
@@ -1,0 +1,7 @@
+package com.cnj.naslink.server;
+
+/**
+ * Responsible for making network calls to connect to and fulfill operations on the freeNAS server.
+ */
+public class NASServer {
+}

--- a/src/app/src/main/res/layout/activity_connect.xml
+++ b/src/app/src/main/res/layout/activity_connect.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".connect.ConnectActivity">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.cnj.naslink.connect.ConnectViewModel" />
+    </data>
+</layout>

--- a/src/app/src/main/res/layout/activity_file_browse.xml
+++ b/src/app/src/main/res/layout/activity_file_browse.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".filebrowse.FileBrowseActivity">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <data>
+
+        <variable
+            name="viewmodel"
+            type="com.cnj.naslink.filebrowse.FileBrowseViewModel" />
+    </data>
+</layout>

--- a/src/app/src/test/java/com/cnj/naslink/connect/ConnectViewModelTest.java
+++ b/src/app/src/test/java/com/cnj/naslink/connect/ConnectViewModelTest.java
@@ -1,0 +1,7 @@
+package com.cnj.naslink.connect;
+
+/**
+ * Contains the unit tests for the {@link ConnectViewModel} class.
+ */
+public class ConnectViewModelTest {
+}

--- a/src/app/src/test/java/com/cnj/naslink/filebrowse/FileBrowseViewModelTest.java
+++ b/src/app/src/test/java/com/cnj/naslink/filebrowse/FileBrowseViewModelTest.java
@@ -1,0 +1,7 @@
+package com.cnj.naslink.filebrowse;
+
+/**
+ * Contains unit tests for the {@link FileBrowseViewModel} class.
+ */
+public class FileBrowseViewModelTest {
+}

--- a/src/app/src/test/java/com/cnj/naslink/server/NASServerTest.java
+++ b/src/app/src/test/java/com/cnj/naslink/server/NASServerTest.java
@@ -1,0 +1,7 @@
+package com.cnj.naslink.server;
+
+/**
+ * Contains unit tests for the {@link NASServer} class.
+ */
+public class NASServerTest {
+}


### PR DESCRIPTION
This commit creates the stubs to be used in the first phase of
development. It also wires up databinding and updates some libraries
that were being used.

Not included are any class definitions or dependencies (execpt for the
aforementioned view model data binding) or any utility classes as I am
unable to predict where those may spring up.

If NASServer becomes too large of a class, it may be useful to split it
up, but for now I made all NAS operations go through it.